### PR TITLE
remove unnecessary null termination

### DIFF
--- a/src/root.zig
+++ b/src/root.zig
@@ -71,7 +71,7 @@ pub const Zone = struct {
         if (enabled) impl.c.___tracy_emit_zone_end(self.ctx);
     }
 
-    pub inline fn text(self: @This(), txt: [:0]const u8) void {
+    pub inline fn text(self: @This(), txt: []const u8) void {
         if (enabled) impl.c.___tracy_emit_zone_text(self.ctx, txt.ptr, txt.len);
     }
 
@@ -83,7 +83,7 @@ pub const Zone = struct {
         if (enabled) impl.c.___tracy_emit_zone_value(self.ctx, val);
     }
 
-    pub inline fn name(self: @This(), txt: [:0]const u8) void {
+    pub inline fn name(self: @This(), txt: []const u8) void {
         if (enabled) impl.c.___tracy_emit_zone_name(self.ctx, txt.ptr, txt.len);
     }
 };


### PR DESCRIPTION
The null termination in `Zone.text/name` is unnecessary.

The size of the string is explicitly passed to tracy and the [implementation](https://github.com/wolfpld/tracy/blob/873c6ecac8bc324509bbd8ddbf62096b3b8153de/public/client/TracyProfiler.cpp#L4398-L4438) does not rely on any null termination.